### PR TITLE
Land through a PR and a merge queue, not by pushing main

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,55 @@
+name: merge gate
+run-name: gating
+
+# The gate the merge queue runs on the candidate merge (this branch onto the
+# main it will land on), and on the PR itself so a red branch never enqueues.
+on:
+    pull_request:
+    merge_group:
+
+jobs:
+    typescript:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - run: npm i
+            - run: npm run test-full
+
+    calculator:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Build the page
+              run: python tools/build.py
+              working-directory: src/calculator
+
+            # index.html is committed, so a stale one means someone edited the
+            # sources without rebuilding — the page a reviewer sees would not be
+            # the page the sources make.
+            - name: The committed page matches its sources
+              run: git diff --exit-code -- index.html
+              working-directory: src/calculator
+
+            - name: The maths, against the workbook itself
+              run: node tools/coreSpec.mjs
+              working-directory: src/calculator
+
+            - name: The prime-factor tables and speller
+              run: node tools/primeFactorSpec.mjs
+              working-directory: src/calculator
+
+            - name: The UI, in headless Chrome
+              run: python tools/runInteractionSpec.py
+              working-directory: src/calculator
+              env:
+                  BROWSER: /usr/bin/google-chrome

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# sagittal-app — Project Instructions
+
+Web apps for the Sagittal notation system. Sub-apps live under `src/` — `calculator` (the JI
+notation calculator, a self-contained page with its own Python build), `notator` and `jiPitch`
+(placeholders), and `xtras` (the archived old site, copied verbatim). Each has a build target in
+`bin/` wired into `bin/build.sh` and `package.json`, and is served at its own path.
+
+This repo is a submodule of `sagittal-main`. When you finish here, record the new commit there —
+see `sagittal-main/CLAUDE.md`.
+
+## Land by opening a PR — the merge queue gates and merges it
+
+**Never merge into the main checkout, and never push to `main`.** You push your branch, open a PR,
+and enqueue it. The queue builds the candidate merge of your PR onto the current `main`, runs
+`.github/workflows/merge-gate.yml` on *that candidate*, and fast-forwards `main` only if it is
+green — so what lands is exactly what was validated, even when several agents are landing at once.
+
+**Enqueuing is the LAST step, and it is gated on the user's approval.** The sequence for any
+user-visible change is: commit → rebase → push → open the PR → **publish a preview and show the
+user** → *wait for their OK* → **then** enqueue. Do not arm auto-merge on work they have not seen.
+
+```bash
+# STEP 1 — from your worktree, on your claude/<name> branch, with your work committed:
+git fetch origin && git rebase origin/main    # rebase onto the LATEST main first
+git push -u origin HEAD                       # --force-with-lease if the rebase rewrote pushed commits
+gh pr create --fill --base main
+# then publish your preview and hand the user the URL (see "Previewing unlanded work").
+# STOP HERE — do NOT enqueue yet.
+
+# STEP 2 — ONLY after the user has previewed and said it looks right:
+gh pr merge --auto                            # enqueue; the queue lands it when the gate is green
+```
+
+**Always rebase onto the latest `main` before you present, and never present a branch that is
+behind `main` or conflicted.** The user reviews the preview as the thing that will land, so it has
+to sit on top of everything that landed since you started. Verify rather than assume:
+
+```bash
+git fetch origin -q
+test "$(git rev-list --count HEAD..origin/main)" -eq 0 || echo "BEHIND main — rebase before presenting"
+gh pr view <N> --json mergeable,mergeStateStatus -q '"\(.mergeable) \(.mergeStateStatus)"'
+```
+
+Present only when the branch is 0 commits behind `main` and `mergeable` is `MERGEABLE`. `mergeable`
+takes a moment to recompute after a push, so poll until it settles off `UNKNOWN`. A
+`mergeStateStatus` of `BLOCKED` is not a conflict — it means the gate has not run yet, which is
+normal before you enqueue; key on `mergeable`.
+
+**Don't ask meta-questions about the flow.** Publish the preview automatically — don't ask whether
+they want one — and treat their approval of it as the go-ahead to enqueue. You never need separate
+permission to merge. Skip the preview-and-wait only when the change has no user-visible surface
+(internal refactor, tests, CI, docs) or they told you to just land it; then STEP 1 and STEP 2 run
+back to back.
+
+**Enqueuing is not the finish line — landing is.** On a moving `main` a PR routinely goes `DIRTY`
+or gets dropped from the queue on a red candidate, and then sits unmerged forever unless you act.
+Watch both the candidate run *and* the PR's own checks: a `merge_group` failure never appears in
+`gh pr checks`, and a failed `pull_request` check leaves auto-merge armed but never firing.
+
+```bash
+# Run in the background. Exits — and re-engages you — only when there is something to do:
+#   0  merged           → report "PR #N merged" once, then stop
+#   10 conflicts(DIRTY) → rebase onto main, push --force-with-lease, re-enqueue
+#   11 candidate failed → read the merge_group run log, fix, push, re-enqueue
+#   12 closed           → unexpected; surface to the user
+#   13 PR check failed  → read the failing pull_request run log, fix, push (auto-merge stays armed)
+pr=$(gh pr view --json number -q .number)
+mg() { gh run list --event merge_group --limit 20 --json databaseId,status,conclusion,headBranch \
+  -q "[.[]|select(.headBranch|contains(\"pr-$pr-\"))]|sort_by(.databaseId)|last|\"\(.databaseId) \(.conclusion//\"none\")\""; }
+base=$(mg); base=${base%% *}; base=${base:-0}
+while :; do
+  st=$(gh pr view "$pr" --json state -q .state)
+  [ "$st" = MERGED ] && exit 0
+  [ "$st" = CLOSED ] && exit 12
+  [ "$(gh pr view "$pr" --json mergeStateStatus -q .mergeStateStatus)" = DIRTY ] && exit 10
+  if gh pr checks "$pr" 2>/dev/null | grep -qiw fail; then exit 13; fi
+  latest=$(mg); rid=${latest%% *}
+  if [ -n "$rid" ] && [ "${rid:-0}" -gt "$base" ] 2>/dev/null; then
+    case "$latest" in *failure) exit 11;; esac
+  fi
+  sleep 45
+done
+```
+
+To update a branch that is still queued you must dequeue it first — a force-push is rejected while
+it sits in the queue:
+
+```bash
+gh api graphql -f query='mutation($id:ID!){dequeuePullRequest(input:{id:$id}){mergeQueueEntry{position}}}' \
+  -f id="$(gh pr view "$pr" --json id -q .id)"
+```
+
+**Delete your remote branch once the PR is terminal — but only on a positive merge check.**
+Deleting the head branch of a still-open PR auto-closes it unmerged, and the work silently never
+ships. Never key that on a watcher exit code:
+
+```bash
+gh pr view "$pr" --json state,mergedAt -q '.state + " " + (.mergedAt // "null")'
+# delete ONLY when this prints "MERGED <timestamp>"
+git push origin --delete "$br"
+```
+
+Leave the local branch and the worktree alone — you are checked out on them.
+
+## The gate
+
+`.github/workflows/merge-gate.yml` runs on every PR and on every queue candidate:
+
+- `npm run test-full` — the TypeScript suite.
+- The calculator's three suites: `node tools/coreSpec.mjs` (its maths against the workbook itself),
+  `node tools/primeFactorSpec.mjs`, and `python tools/runInteractionSpec.py` (the built page driven
+  in headless Chrome). Run them locally before you push; they are fast.
+- `git diff --exit-code -- index.html` after a rebuild, because `src/calculator/index.html` is
+  committed. **Rebuild and commit the page whenever you touch its sources** (`python
+  tools/build.py`), or the gate fails and the page a reviewer sees is not the page the sources make.
+
+## Previewing unlanded work
+
+The user cannot check out your branch — it is held by your worktree — and the deployed site only
+ever shows `main`. So for any user-visible change, publish a preview of *your branch's build* and
+give them the link as a matter of course, as part of STEP 1.
+
+The calculator builds to a single self-contained `index.html`, so a preview is that file — nothing
+to serve, no port to hold. If you publish it somewhere that names pages by their `<title>`, copy the
+built page **outside the repo** first and swap the title there for "what you are building — your
+branch"; never rename the title in `src/calculator/src/template.html`, which is shared source.
+Re-publish the same path when your work changes, so the link the user is holding stays live.
+
+## Working alongside other agents
+
+Several agents are usually working here at once, each in its own worktree, all pushing to this repo.
+
+- Rebase onto `origin/main` rather than assuming your copy is current, and re-run the gates after
+  it moves under you.
+- **The shared checkout often holds another agent's uncommitted edits.** Never move them aside — no
+  stash, no checkout over them, no merging on top of them. Work in your own worktree, off a
+  committed branch; a build of the shared tree is a mixture nobody asked for.
+- Two agents editing the same file will not conflict textually as often as they will collide
+  semantically — duplicate identifiers in the spec file, two rules fighting over the same selector.
+  After a rebase, run the suites before you present.

--- a/src/calculator/tools/runInteractionSpec.py
+++ b/src/calculator/tools/runInteractionSpec.py
@@ -19,11 +19,15 @@ import sys
 from paths import DIST, INDEX, ROOT, TOOLS
 
 BROWSERS = [p for p in [
+    os.environ.get("BROWSER"),                  # CI, and any other non-Windows host
     r"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
     r"C:\Program Files\Microsoft\Edge\Application\msedge.exe",
     r"C:\Program Files\Google\Chrome\Application\chrome.exe",
     r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
-] if os.path.exists(p)]
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium-browser",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+] if p and os.path.exists(p)]
 if not BROWSERS:
     sys.exit("no Edge or Chrome found to run the spec in")
 


### PR DESCRIPTION
Brings the PR + merge-queue workflow over from the `rtt-python` project, where it has been carrying multi-agent work.

Right now several agents work in this repo at once and each pushes straight to `main`, which means whoever pushes last validated a `main` that no longer exists. A merge queue gates the *candidate merge* — a branch onto the `main` it will actually land on — so what lands is what was tested, and serialization stops being something agents hand-coordinate.

## What's here

- **`CLAUDE.md`** — the workflow, adapted to this repo: rebase → push → open the PR → publish a preview → wait for approval → enqueue; watch the PR to a terminal state, because a `DIRTY` branch or a dropped candidate otherwise sits unmerged forever; delete the remote branch only on a positive merge check, since deleting an open PR's head auto-closes it unmerged. Plus what this repo's concurrency actually costs us — never move another agent's uncommitted work aside.
- **`.github/workflows/merge-gate.yml`** — the gate, on `pull_request` and `merge_group`: the TypeScript suite, the calculator's three suites, and a rebuild-and-diff of the committed `src/calculator/index.html` so a page edited without being rebuilt cannot land.
- **`runInteractionSpec.py`** — takes a `$BROWSER` override and knows the usual Linux/macOS Chrome paths, so the UI suite runs somewhere other than one Windows machine.

## Still needed, and only the repo owner can do it

The queue itself is a repo setting, not a file. This PR is inert until:

- `allow_auto_merge` is enabled (currently false, so `gh pr merge --auto` fails),
- `main` gets branch protection with the merge queue turned on and `merge gate` required.

Worth timing deliberately: the moment protection lands, direct pushes to `main` stop working for everyone, including agents mid-flight.
