### PR TITLE
Let the reader pick the palette: Auto, Light or Dark

### DIFF
--- a/src/calculator/README.md
+++ b/src/calculator/README.md
@@ -10,7 +10,9 @@ input panel picks which notation is on screen, one at a time: *Precision Level* 
 all four levels, with a live diagram of where your pitch falls among each level's
 symbols; *Prime Factor* spells the same pitch in the prime-factor notation
 ([t=99](http://forum.sagittal.org/viewtopic.php?t=99)): one Sagittal per prime
-factor, with the factor-by-factor arithmetic laid out.
+factor, with the factor-by-factor arithmetic laid out. A control in the heading
+picks the palette — *Auto* follows the operating system, *Light* and *Dark*
+override it and are remembered.
 
 The build is a single self-contained `index.html`: no server, no network, no font
 to install.
@@ -57,8 +59,8 @@ recalculated from the workbook's own formulas (`tools/oracle.py` produces
 extreme-level tables and font subset, and pins the speller's spellings, symbol
 order and cents reconciliation. `runInteractionSpec.py` drives the built page and
 asserts the behaviour of the inputs, the linked ratio/vector, the collapsing
-columns, the copy buttons, the notation tabs, the diagram and the prime-factor
-section.
+columns, the copy buttons, the notation tabs, the diagram, the prime-factor
+section and the theme control.
 
 ## How it fits into this repo
 

--- a/src/calculator/index.html
+++ b/src/calculator/index.html
@@ -16,12 +16,31 @@
   (https://scripts.sil.org/OFL). The subset uses the family name
   "SagittalGlyphs" per the OFL's Reserved Font Name rules.
 -->
+<script>
+// Settle the palette before the first paint, or the page flashes the other one.
+// data-theme carries the resolved palette the stylesheet keys on; the choice
+// behind it may be "auto", which tracks the OS for as long as it stays there.
+(() => {
+  "use strict";
+  const root = document.documentElement;
+  let stored = null;
+  try { stored = localStorage.getItem("sagittalCalculatorTheme"); } catch (e) { /* no storage */ }
+  const choice = stored === "light" || stored === "dark" ? stored : "auto";
+  root.dataset.themeChoice = choice;
+  root.dataset.theme = choice !== "auto" ? choice
+    : matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+})();
+</script>
 <style>
   @font-face {
     font-family: "SagittalGlyphs";
     src: url(data:font/woff2;base64,d09GMk9UVE8AADIkAAwAAAAAgsQAADHTAAEI9QAAAAAAAAAAAAAAAAAAAAAAAAAADYGuABoWG4QAHCAGYACBNAE2AiQDhxQEBgXHFAcgG/GBNeLNrnKgO0BFvW4oWhQCG0cAY77ikQiTSpHF/39SsjVkD93+AV1zM8sMoQgkszIausqT5NFVWDo6vbcXCHNhCBdHXggk70SCmcl4KquEq05U1TPOhtbanNUGhI6BxHQ/nB3zXqjjslx+n7XsQuLnyF/H2X4eJt29/+EEXfIwwyzzW7zBAClBdEiCGDuCIAiCoGFYgTjT9v7KdLbpBEEjK0ufgkT7AV87A9tG/iQnrx/s779zZubCX1xKkaxuG9I2uW4CSwP9vDlHpExuutsTuLQ8SHGknlABavMD5xxYVb0D5K1vnskZ7n/PTzWn0X8vlQL0dlkOkVHbykG2gyy1bC1QyS5ogW6BrMxaAYNC78eSnP0qKIRWGLwdhRSgOjnqXm3NA/19+3Nfy07LTiVQ42keBZJuGjaNZ2mAzcOAssZ3oPoLPR9a+wY+X0LB06VGiFxDzPbv2croGz9xz3iykAndwTgYsd2iKMV/AOQ/EMDWsgn3DeHgJa2GIunjLxL0O1qOUuUqeui+1QhJk8yEUoXBbpjJ3386/RQkblrRX0ZKa6Q0OUUpDTsDdgcnJvZDtsFFFIFYoV2KSvVBIIT67korCVEWj8FEcpEbTsGR0iqvQNIfrzSXu/PuzngIL/2m4k34fSp+5VTOIKaAf80AlM+BKeEtw/3v73vRmjuPSB9axD2b4AYnOm1okf7zNx8DwcADSnSKh9kY+75T+48JIttiBdBvi9ncjIM0YJhYPIa6SPyK/NfUrKep1s6aQU6pS+BLuXJCgCTepAckvcryYRtsb8AKBaLo5r/zdhggLmgSBppJCgljZr/k5+nSo83dbja5X1pRlCZRebnfCjgGYRk0tgst8P9f1ay9730oQE4fwEhOLOCc+lh07hrwv0+BgkQliqPkSDlq5DEHnJkzphxEgLS9MQQ5JG7kbAih2rNFE3Kdi67cejMPPJfT+zcaGGtGc2ovsTA8ahtFWbZwTIs9//tl/ez0JkXYIAwhGheVw5ite0/PqZlbp5qQe4Of+T8r8gvzNiQN2YISKBSFkhiFdUkhJC5sKlnXtVMD6LvDYEyrHcv1ZoQAURRcuiD69Rib9FFhI/ZoOatZmhd9vdm99/2sNlqLiCgRERFtjPtMFoGBLVPerr4+367y1cPTx8fV678UdF187e0O+Yd7/5fjP8nRnKw4w+yfSaOfMWCb93N+1vwtVbat2a25xflXst5HWeTLNGjXTV9DjDZJtdU2abDdHkbd+rn5hbAyJs047KQPVGrQrs+oGctKwRixhjQlmgyYs8sJ3+A6buY2NrGFJjK085/8mMu5imu4kf9hnDt5gEd5hpd5lbf5iDl3A3j4w6HiEFMxYE4tG9mCnt20Y6YPFwOMkCDNBNMc4gTv45JQM7Hx4E9R9fKTUtTQN7Pj2FWutd6t7tRgp7Q2vQ4ZkXfUKWc96pymgbmd8PTtfyuze7+xU2YvWrn+ZqvZhr21xu1a26j1zjlYcPEJG9+BFXZ8781ZvGrj1t33WyHp7I1MSM8rrWnUytZU19vtaG8dWbLmabBwXNnEDnakU83nl9XGOnr1r/LhUJAxZJZQoWdl/da7jQ9+9i9OftS5gahYddAAwksOXgARJpRxIT2ljc3NBogwoYwLqY3NzQGIMKGMC+kpbWxuLkCESXQegAgTyriQntLG5uYFiDChjAvpKW1sbgYgwoSyeBkNAMBGSE9pY3OVKUmSbJAkaSckFVDm8gUAAAAAgMqGJEmSJLc21yBJkiRJkszMzMzMzMxqEQGCIAiCIAiCIMgmSGgpUBRFUTT0vLl/6y7g8bo8u76VOu6PU/6RrdDnuU5S2UKGalSSIzd1Gwfvphg4KjVCSJyNLylirnxkZXWv2UCND8fVlWAzs7/dw2UV/8G3ZeEKcBINN9fDySAptKIJ0lNoumBTFF3ygVgj85Rom5FW2iwQO1Za9Q8G9HkJLD1BuLQw2K2otED7A83pBKH6yxQKxeaCzMzeKrNUNy/eQg5Xd21eUHo6P2//GFbkefoyIWhTjyaqkm4dmR/Dx+mcTj4ySATtROQwKdOI2wGAVXLvSHfYyXYsT5ePi3Zl/B8HBzRUmPe9SeXqPJQGXqVJ2tFdBkpzjL5F+Z2+fhJhxiQbrNsHI8trFDNxXgrI8ZxOoMtRZEq6D5Q0lb+mN/fOP58GCQpgf/9JHWtgVCxNMi0EnF6WLSbCiBW5WzRXD1Q2Lu7aphU6OB9IU0ghfs6fDLmtcxf8JN501CEIX+4A/sF1ElRlAmWBc3VwMuLwMC/fKMrIURJz+NQKegB0ArwfaXM9TzEZyWFKaFCLTAVCeeNAj/DJS32qc42yt1xecgEwT+FA3sjr5f8c7VOty/v6HmlhqI0KXAUtJHo7NSi3fuPjNH5kOFguF6Qf83vr2kPrywxSjK0mmR5zBAtNbdB2Tvs6qkhz4KLYUtIHEOBBSC30AswK5ZY4wReHHkXmqphqgcCCCaS9c0Q+PkVM0m+vf39OeQKpUtsqJ46TwzCTYP9qEmeEtHmolTxvhbPowgfCD/gj8+6F0thnZVRMYm8d8FSV+qILz0ExPTe2kUIMBsDFroUgwmxjCpch9XGdfHynPDZHjKyieQ3xzgqfaSwQwjF9XYvYF2fomIMuHBst+QJq/rCoYiPI/qiFIqCjgy3nQEFXAEx3RXKX6web92Z1suH/HHwJo0DlzSeTAgZFvqIngw8wKtBagr3W2F+GTm3U89SqLKDbtGm712jvI2upN5Kiu9aFjPOJSg3UIw+R7KdPvVbm7Y4Tgwv2YUtK/g60/5E5MI4hHQ0+cobc4yr8ElouJkxTN0qtWaYbNoFG0D6n+KtRMjYH8e3cGRBgnMq1hag3E+UjQDeZg3AU7UzvOR0LbV5dtwboSJY4Egq071YTKICc3uAk7ToQzOhh5uWsZ5RNIa56KdNwOt3CvCCb6CCLXO3S5oQvpM0ek6SNe6h+I61TQA2Q0iaErBBGkFoYsyap4jFVr3fUS2rhf1mHTs7JDdnEYMmGvQlWw+GevHzOom8hr1HQvzwMRufC1khE8ThetbJC6alBBl8IF6J8HhpW5uAyFWzmdxClOd4Oc6y59ynRZ7Yu36vG0GSLk6WYseeZo+hqsU0SJlxMVOtazJs0jX1zIjs8PiZvGHXEYbu21msR7f8SzWr286DYMcNfQkqfWlNiqARUTn6iSk4dxCjIdoi2nQ7OmnYWcoTS7sIsVV5zE11n4zpvVJi7qxUzQXbPzSd0nq0wwNPkemFTdQvhrPh0X1jGnlF0q8OmvZXQATk4uAM++r5J9HDG6WDvuReVZosjuh5iu3OXPyBPjvT+TLi9FLyKS4/YqThbjNy+CC5MLNDk3kZ4CbK7tgXkzZVNkzf3THIJhs7unRdcQe82N4JAAQde9FU7Svm57Dr/WXhEPNCa7q04Hdk8/svMRs//n3cSQylAE8LGQVZxfN3T7tEMuzmEgfgy0i0UDLz94jAOZYlL5dK8yuj+uCiryZBTw5hhodk9C7n1m1ItMJQ09JjdtiQVNo9Mzhnx5DWVHPs/QPyfZmOD4cira4DU4n+24yYu8R5L5Z5k8rUkzXSsTvpMrZp62G9rMWU3rbBN9k2BM9j5c9719Wjm0u25Nzfk7ncfee3ezct5R73v/D7+wR/29wcymBn0BAeDb8Ph4SecDO9Hz0TfaCI6FWfFw/gdp+NTSXZyTw6lT6UtaZLu0z2pmN7KCrM2O1PVWe7JG3JU/qMi4CHKqzKvdlL31AH1iPp3zakdahOapE/QU/oFo4uxbASMb812xHSz3WTND83HVn9r3wpa79mCmm077BP2Oae/c+pknV/d3u6hm3J/9/K8G++w9wt0gBmcQhr+RHqSC1IgBJ/FKzyAf/e7+Ju+3/8gaClNDlqDePBJ2ELuF26F3WEiXIh+FG1HkWg5HhJfxJn4kzidDE7ek+PJ/9OB6WNaTOVsdLYvm8ue5APz1/zL4nLUe/F1+W/le/lp5awOq4nqf/WQ+qv+vOnQrDSJ5pe2d3veJtuvup7dQzfXr4q8p2sW5E3lXcvPzl+az+enCp4pKCs4Xdix0FO4vxC6RkMnV1eXyzXSVeN6y7XTFX/lWmixQuiEeOJQTe5SOCO1ONByoKLKbgyIKQgn5o1f9fYmAvP6BXvKh0/ugMzO45NqlqIzn8Hyplmowc4eUHiIkKo9kR2jaGtarBhaKxan8uJk7kbaj+3Rz6Z90/8p7fR9Ltkett/9IN9uYjnqsiik05MaWmlLmKPopuafRYIRSKBcV3qn+hlxTtRU/KvKm77PXVnh6GFsDotmKySUJW5qXvtKVqmQiIG5hvdr/1mPoBiEn1yuvZ4l1DRz10n1VzSZ8RdQs/Kfph6rCVArnZnNc+lJzWqK2Yc7UUTpKRgyekD1e3et1VDXSqH1noQev92HuHX9dzOpM/HT1R0aBwTogU8uXX72AA9gzQGThqrBgKgqtPeRc+or8V5N/dzpP0bXa14R9URNQaKucjxu3r6919wGUrzqmJjv6yKKL6Gfx+33Pzh0YgckhA/Om7CyYROhzfjn9JETQtcUO2Ob7rM5KbqsW6IkNfsos6kptB44M/svVZ2dh49fhfIn0R6gzl80B1vXRV7Hzi/Sa6YOiu9OhXDCb9F74hM7f/9YCu2VLK5mRXYcV4eIDcWTKNCRBvjnywSGAii8JqrHBKila/TgbCotaqqIdQQpFFZ6ZgzZbYDqm5vWa64tv7+jBZy4UNsySixUF/sJ9lK32TNtPPvdlBZbJ3+e3BS9fCSn6mZ/Xqm62zPA4Ob7h+DmjXQtvin+680/62QNsxXtZbN63g1bvYa39J6z+nSpL/Wj/n0OsGe+7m/DwzU30hcY/vKFg1jgRKc7TMu/YH6cTfr2E+ypnrKb8x9UWnvGbZi0aTwg2Oa0ZRRQXsgvaXziVQdNqz3kHnD5O8Kd75ubRMqUBoFIMJ3mXb022OjgLrrP5euwda43336wdCZVOrW8kmHGiYgDwJPkNcYHQGUAwmBHmkVsLaUlJ11ZYLEdAw1MXnktplePgJFm2XBbBsBe0WueLx2YzxZexRjEiBAaQEotAxLOgMZiDKL0hMER8CWYsZIBHAfjpxuQHLSJaui8MScTFHle5nU0paLAGMySI7dxZkH46hjToypDM9M0aXQ+SxhiBOGMcDgR6I/0i0riDECEGGB8sMUKgmkM5I+2ymqdcTIlJ60sae7Y/LilsVo1oYtBQ+MKjaQbKgDitWgv0koWDtmslXowXFh8P0IQm8ZA3KOnnDAPDiYswMeBDyWDeEQTBtlC2wAgwixUjcg/F9qQd04dZKbGhOA5NhebiTSxxhSNmNCYGaw8lcsvaUrFq1a6U/0qdWCpP811dWub0WRz+pz7XIBMVm7/ZL66xpA1pw6CqQkheJo1xpoiM2wuxSFMaELO1WuDjVYO5IHqus5he5oqnH7nwNMwvScBJTcz93llQfDxHiTbaMlY3piFZqhDy9swN3aHM0cIBEcO/fwQkkjeJyVMwxxCda4HfaFISEVp9ZSLuFET4C8A2pWiMA+8TMMmDJIwMn6SQAQgwkzStqyzBSKUwk+J88sanklcUyqjhOe2M2L9KT1UIzKPaiy1assC5QURGMwAoQKWSN4rmsrDZ2jFV92lXvSh6PCiIs0apIzPF6cBIRkW52qssdxmKetEBIwbdFSBuLw25gEgAhATA4QTksRmLMqgUejO9S/y4/Ek6034WBiGAAT8SBXWubK0XHPWp0H5SgfzppoIU33JBMFWU3KquJYktZkXZTAnJHPR9d2HJ9nBhJ+S9iFM5Lh3tR6qd9R1sF6tibDUQtxsqQvEtx5tKTMx98y9TWTDdpK17AHKryUYN3jC/hACiF9HGMSfS5KSGVZ3ZhPy9kDJXtT4BE/SGTDWmvJ6bA9srY+OEcVeUaRBIvnUfmEoGUQSZXanhP1wRI0WRnvwtQpVgUm0psd4kh1Ujek7iSNNAMxoSBN5NSGkkfdxFFJqWSWT3MFwSQDjFwCf+bMJg/hdhEH8LsJKJiSqaxCAZM5Sc+Jcq8jpzhekiEAYwj4kO2jJQt7Qwk5YO8VVb0yrRUbxIAAZraIBiD+M0kOy9iOJ5N2ccBDmH7nq9WDeqHzcDAFgc+VCPZw4zMop5YaJRIYfv1xIgdcBGR6xEJGK84TBDBB/IkmQ/cMEIgCz4nGj2RQ+FjeVE5t+xcms3NzGFIihez82oqHc3AFvGIHkdrs4XzHX3u00qh1tCm+IO8o9tsDQgcQyJJJfr9KchY9tQwnGEpYMax4fB6cunqYQmdlAgBuRz0oECidtrRWg9CbvQ9H3DxCIAMQOG8ZXatxmoL9mykZTGXQrF0f9Z1d2PeZd4YrbUGykTKP9E4DK2sX3w9Ct6ifo9+dDjvWNM972JLUyMKaXNOKElu5PmQBdcZYEPP9tHGRGo9b5VxkOZ7yNGdf3ufGxsbv9CVY+r/7ymkNQkM0ZSxXxn1vZ1cTPwxNJzK07ozgbuX07vLoEk6O20R45phjTGQs0zNki4XOkBcAPxojd97e/A1/O+PwoDyg1u6AQ19VfqhyU7arX8Zxi8gDvf4iT2J3OkZes8XrVFz62gdq4KDKCAcY/ANzOHC4f0mwRsGIY/CI8wwYbXPq8k0hRmoxM5/XWnlcsxkIE3xvT0vFIZoCRjYlGgB9MQ7eECwteD6ze19LiD5Oq0PgkYwHDaSOAczjjKZwEVmGgVAnzY29kgOEDiBADhMEQgXhiX4sLxHWqkliWFRHp1OiUcQPHsIBEVkW+fDdtVf+TvANePxO2vE81+XezzGBsXp9nnw+QzcPtH113B72imiAvhAxrQCAORI61elJ1c2jc5/UxNsv6Fh03Be1hKrx+z0Dj0nt0Y9AybvXPHKwaA1ZKHRcBGB4KhBBZ1eiRwWn/nWHTKfNfkU9QWLSMtw9Qg9LH1BCQ7X5vhZU74KUYegJ2hMGdBa8NnTZTvfkhgBpdYiy3jGsuEJbeJCcNjY6MLEsRqfktQIT5icvFVbXUnAgtIrJjKYHZxm9IJyuIT7D3K8E9gmsWLFlAhZQExtz+Dgm/hvXPviFtroBP9NdMegQ3LfBUMiY95vZ1CIbzf0p4Ff7sXgnGRHWQJzQmBAuJeHQ83si2CZYAbt3iprydUpvzUh/AUDsNhlVR0AMo/vD2RtviBXZc4OO3GyxLlIWRMj7Ikk4x08TfZDLBTcaKsTa2lwUk4HcqLsVE4wqNKTB4LdHo1IkRoPL0EtW9c4bR6ga3zwOIdrDaelRRlSc/y6XymGCa5JtM9nAtsYbYOBsvhk8h6RYWQQaKz6untdS3PnuMAeV3mT3elapYKzBqSz0gfuvN/KLUvTjpmMUNiuD3IoBU+jguAWFdRIIoNxV+JVrlsHLYL/F6qmGsc77dudDFfXv655BOtHrQyphsKyJGVB++IurLNuWwX+LzVHwsK2l3LnRxX9VfR6iYJoD+qKsCTIjRE8xkMXod0w8TM3zx23lw8x0iOcETgYm0AcZPAD73JxIG0dsJx+9NwJGkVs/Eg3vlRoQUO7FujTLRmjaPOl6B9xwwpS+a8m2SlbaaWjoTFe6VcwhmtnXRGmViIp0aHXkFnqHXsT+K4DdqSzR8rSpWUHdLQcnjPRKKc0gW5LD1txfCjtJuo3eXelbnGtVc6VqVp6DuhGRoj9Mo3aGIgrPe2jueXjJaVtdtMnE67cQikqHURGIhkR/f198ADHBmcVLhcGT4cZJA/M2EiczcahIJcSwUnhSnyykY3sFS7g8Jg5kBvdupKy3U67uJ2+tOHw8Im8XmsrlVWqTMLo/gzezTMwNIjjxsNT5ZMd4RK1JvTZuzs0umWzJR+ng9dIv6SfrdhZCjSCeKc0zjkxVDHzEh9Yl0KjurZLolE6XVHo5UcCszXoKgeJ1/FXGRgHgwGkV+r+P+XXUrSoxUZ7ZfBPTRUtXOaP8TGfToc7cyvGw22uVqf46yoFNVlAyxPLqTibD1/Mrub3l3NPE9/+BDRbQ/7kwAKioLQuMKjRYY/DZR72wQL0N7nlmiurfOaLI6weVzAeq0Wjcd8sytyMICcW1nLYCOnCcB+MH4x2g0HnQLiyADxefVM1rq22t7mgLKb+3cfCiGeUxYmT+SYJxuxUU4sjhPhiOg9L+twzOwrBjODOACMdAW9EQIvYeboKoSbV/6Z7t1jrp26B/EhOM4FZMd6Ys1fwPxHbVs956jrj0f3sxEWkx2qDAJaH32K7GLqpWf2FoVTPhVNB7fTmYmuBnyNrfzeklXHuM7yiNLv8eD158pymX6tUds9JkTumqOuIP6JhzVRYWIORHF69Gr5s+KGqZy7O+qlX+1TQQGRPZaFZ/YA54AoAUhhPVaJ3beskSr8xkxC4zJnUUCgchoKDDk5pdABooDPa19IjY5q+HU8s+6uabdYAHUbQsLGp+gtbzhgBfVVSmOGe8FQbldj9iocJ7XBwax/IRE/oXgVUN40lS+41kxY/Nil6QJ4rY/SAQQp1hgC2STOEOn/i/cF3ZGpspe3hMiq/Sa3kng3sppErui5sfCQUCx1fMIg8Ulaa1SsSIUsCFFS04QjiW+RVN7sg07YfULRRbWypcVSzTzoqYtNVQEAPZDS44StiReRGZytmEnrKhQdGGtfFkRxBdpMWiuleX1iuRrzMj8vCLRyFOpiGZ8wjHSXXlmCREk8p8TMnz9vgIx1noFXgBWHD96CZ6e0QKEE5bwuSRBwTRr5xVr5Xy0FoVUxbQ3cwSpFWPDPCHLPseGBCJtaWzEFGGweLx9dXUV4dZsjNXT8F73OO+OY3aYhXzDKzn9KRtaAQtP/oX8jCBoHGeNUPrwq5x1KvwImhqhCEfjZpnbqAkaD64Smbb17b0CxrxlCWW+ZlNnCjiLzTK7URM0ZKAS7WbU0vH0Fi3A+POKMKmaVnY38e5wBRFGH3qRwTqWc+nt4zBVyq0G3pC1ISLGwxQIIAH4Hd7CVGDfRsDycUVezIYJq1KscAd5DoYCtdl1iWpJzT2PtSLbqUSAiP3P8yj03jPOrtu5rro9XmrZXuRdvFYxula1Y55639OBfUqOromhhN/npc9T77s1abpZlWf0U4muyaL1eu0Oy4weqwc8PgBkdbtSSVbMLW2pbJLBcWeD9vQElN86yPlgDE/aZrdqah2Ze9EI+W9N7SM71Xw32zBsO1QSv55S/rr3mbPtHwKGCGVtcdfDy8hndMjKwj5vtjsUECOCddJ9Cr7GAXKaj6tSwCx0oSUwGAgi8tCUWD/+RoaiAOlEiam/Q6NFOaD/lIYeYXgErZBLPTZn3yBDDxitDewNvQEnwiyPFhjBPXV2tCZiCL3DDrToJWzBEtbaYrFiZbaWKN7UqvzYPuyDrO98Zpal1TU6DZQl25qfeFOr8uPQsE+ybvVZWLTL/kyvBYHyK1PP6jnBx6VCXt1KCOSwftKoDhJdZ9ejnrgofnSiEUKijQdBliY+SVbvzOxHJtsnyYqeWRjJZPdKgB1t1br7VawzbGF2ANppZsX2Lpuiu7I0eqm7gnczYyxi2Iz4vSAQt7AjjCE8HQ1nuelkXS8CYZoD0Li88qJWxccBmQ1REtoHT+rKNhJ4DnD8foKskRujWQR6RlsKOL9K0ItUSzFrUZ0YIxhliuE7rWKgJUafMPj7LCBn1x1zRxFFxZvEA/wuAEcePoX70D9wx7yL6sQJQVBQjLZcm1eXquHbl2kmgUQ7YHwQY/bLzU1mQGbrrDbUss2iHZkoEQazRDJAhDj4ujlqZ/TmEhsRQ2hGcUR1PCV9SXqWZJzvqereKsY4aX0YYJji3FN3OBnEZ2YAAwSuRjUfYiM1NlXpSRZ2ySOWVZwjcgvq84mfOq2i9BnZAlBGIaWhaIYBeB2MJwBUK67E4K5XiNI8O43IgEaOxCyyKsxhyU3k5IeiRSSwE4QWthmBWVgqFrMigGGdEYIi4/mWs2Z/SogIhIPhGCL/nc70W9mx4yblwg7b/dP2IVPQ0mbuXQN3tVrkAVKpzPBuoTPch8CylMQE1oBvNzaUCfJtqd4z8BAuH18pBU0RgANHWAciYfUs9DdSlGGDQGKYsuOzQW2kAIk1iPxxs1bO0Yyje5g7ZF5pCyDs1bJ7AYeE7ogNYZbHCpRgDfpO1gDzx+UljHHMiHvqrFR+sstldtuH1S9vbtrj7mJMNOil9AWCZ4WhHJrcGHy9OWrV9LivUlYhPF6ICOfF+jIHi8Qu37EGGUCVl1RqrvA1JeWGQQzXijvLdCRQxvFAcmRTVGCW/LRdZFMX3pjiS0jcPeRWZ195uoLy5ENH3UGvENJ7+Vrb5lZrXyFdpGKF0CeqhdkHFIDPsEfRrB5k4VpaM/LZlADlFzPLsZeiQkOb2Lf9PEhEAGJwZhH21SPCZ8sO7qF46qWJ9FZn1cRNW+1WfvdML5plgte3rblwwZRfLhQiQWQiN0I3h6f5upm4zsDnYPxU0bXNKJS+Sa5W2JvdPSm9pvIW894s+YBmfHiTXEkws7uoEp1Ab9EaTeiJpZWKfDUxR4a8YYjCYWfvq+9ijom/y2wknWTHEFmI1Hq9dsfWGdXWPujz2QBto0LMBlor7MzTh18YS58qfDUJR4YGiQFETm1Nd7PtCJw57uyxPdUB5R9h9oTzQn2euy8VMuNkrrlS8sCGYuVMGzFqo3d3xI8Xs4Zoy17Ojq3aY5lLGy3uNFqNaMA9xvD6euXYXXbuXK2Bzki3gWJw/z10f0vI2rpzTQSykaRBYJI72KZBVa7WeTVown6o4VgMPSVnuyl7m8Bi3zZKVWZBbQrl6+XKStZAokpecXubv9FINd5mJri7qCquNtAOXbE+9N+xJBUSE7dUK+wFAALskNCV6ENgeaxgFIzF+ztI6QXFbBOzZTYgJLn9iIyaaUHJdGL/PSkiyPYc3xUWmMVGeknQ5x0o+i99p8A2CVtm3UI3twdh1MwISuYSCeog+0zySx+usJFZMUvf8C86P4IENgHu1tMAjqWzJk4f71GOhXR8QcCxxJku9pKxuB0X74Xvri4v3FMZfBG4q8sMmaXdZ9eofG5Slw/TiMzpiv9QwRM1eHt2jdqn1OXDPgIpIgAxOLvI3IQn7ypynSjB69hxOcIBPQxG2e3FgZaZgNa38TNGXAu7jqxP7IJqBT30RRLA53oO4fxTJgCDIDpw5YilKTwthI/EdRo+e3LjdYxFQVGmcSdMzivzYnUV3cmMJzd2tlhl6AEzx3mqEqxlt6clPn8R71Y75dIpC4rO1HjBkzxJiYRBfN50YkOGX4xlJDJpBmQQ06JAXS7Dmdv8RYRBfBNhkIpJOuOQ6D29UzVbuk95mSZHz8O8NBi1vZAuK1pqWTXafNyJXtId/yeg1/0FGemygqibPxmNHA9mLHzVqs+rUgKbXvG6NTSbTMJmlGQhpZEvyq8RYR5Jme8ZvzEG9Lnx/1rOKZ7aKy1afhVhEF8gTIS2g8CdUQuHy/cdthqxE1zNxMSgXLDHG8xJUr/nu4/JADYJPpP7Q4J+kfqzZDQMAjCmlCqtEPFXEQYpJgMi+hCMB+MxANWK82xgC3Jl6fdE0lji2cd3wzFyCA76GR9ix+SSSx2/y+vSnCtLtYTpEtGNMA6MxwFUgzs31LYUkK628moIU25wS8XkXEQMI8YMx79EebTsjKekLFCr9pID4sJaBOL3FM23gB7luOT7SOKx331yc2zkipFk+Q6salDEQzE2nD63+V03aa9q4cofo4mxooFpIFQytnfV3fk/xWmHIQvE540igFGyrz3GhLtQscstwSYg1bQBO4pM0Z3733Ogs9WsOitBQ7qoYXX4bh6BDOK+TkrBz/0qm/eBvipbABWtxl44fVQJnxzaNUWwXGUjjHkb0qVXynoVfnwHtF2DikBDnSpTWpi/77vzcyAojj67uKz0lItjz+7PMOU7x+75e7cG6nAEe77tnrN3S+AVHAHPt+0HfmkIK5ot7HZ4MN0d30pmJ7gY8uboT4dt5/HtQLQsWAFPTwqfaSvfdTot1Dk7ZO6OP3HVHnEFyZsjQR0On8e3A9GyUQHPAAp/WcP3K4TxQXre4WhcPvdj/bGnqOgrS/uevAppnEf3Y9HYU1J0lmuee952bvI6Wb6s6Omhtn+SqeqB5MkGtRhAhhJPywAt+yiBqXhbhWDy0uUNLZ2sqsgO80ozqqcnktkqRnsMChKM4tl/5vmnkkqUFNc+wVBViip/Ljc0lAQfTxEtPx4sKZUakkFjOUdOPV5bUlPqSVYRVRmZg6uvfLP/6pASO6NHTXKldklbBNBy9rCRjfxWEukpfTlLhwQlLFvlpKQ0SxuqaKV7zVsLG2Bn+86Z5tY9NMcvWm6VhYU1wPzQ5MzU0M8v+jP28f5K5JJt4EXRmhPKOnIGCQWpS8sjoh4Pv0qMoicPGVqRZiohgPv/tTMjtTi6OTeBOfTex3M0X2q++pRLoQRyyG54QHzCJsGg7tWO1BxGuqzR0FqDxJAV5/qgg+VUUPk6B0rJClBy/ji1wp99H0ZrAP2hy44zL8ve+bjnWAINLKIb3RD1Jvib+3z0hnwOHb01Gj+q07fTASXoQUB0c6frjfZ67VgncA+/OZAf0gvLz077T1SRZ9lRWobeczcR/UinJdPdR9tvN/CmYIqUpe88BxGB+gIZKEO9iU2Vibactpf3Whuc5KJ3lPjImSnxK/XQSjMqqHhTzMDPvsMM7Y9NISJIww0zz/EUT+UTmdM3F9+8BAUzyhLp1DgmsaBXOutNDiQmsTLSQT6EAQzaEEkteDOEQWhttA79vbN96MPQA9dKUkE3nPhOrCN2YxVDYph7UmM+MQ2Q7FhHuDOKiP6lgX6/gj8BpxwGMeBi8N4MYBBbIlxHgkQyRmpcqAQJ60jvtKMV6RLvJzXCs8zFLalJ0aBvoUxI+SgcLwlSCxr+7B2stuihq29Qou1B2spIVhPKq1LotlaQ19uvIkfXX786yqPhk4thA+ewxsoQteOvpx0+YeUhHx3KHDHp7KO3MiRr3B/gdOyGnb19Niet0QvHX8GyRC9+4lD0wOoA1uSgbUv1IbKj4xluJjc+lsz6X/SvH/QOOdoPaBAaZOvsr2Vzw302722LNgwgl9ICfU7G7vQ47PYoRoRhv1ePgODFURKBzxJdNQuM3UcDDJDtH/CO8gp6uBvW8Lqh33N4nKUNC7/BxYPFvWffR4cBufbTP22znMpPZmESwrunjQ1b39zaduF1yQFe0PCR87CpIUQgNDAoUuHjhmHEO+wM9Q/TYNZpm+fxeYeRY3ZYU77szw9mO86VF9EWuFj6Tbi5hu7RF3M6BJpzvz7xcng2W7e/ztYNLbN+fK27z11UmZNy0WVYiTYooXTRn51ZLJ8iWWF+FSxqzjX+mn0cEmqW+93p3bcv+nr8vbGk6UvKfadeOqxMJ7p/wYevtxbk7EcXvOxtFiwcV09rx1ixuKrmK8axmbsKhJOFQxJG1ZW09s9gVp2Tu9PmRT7Md5niRf7kT/7E9w6B/DkjZCQL3sFZGm/9buXxctyPy/OwlDbHD/p/t/xF43+l5+J171Y0xktLT051Petgckk/6p3zIt3jRrpdLYI68102+DCPYIp38CeL/Im79w6B/PVjhLNoh5uFyKIgbOwr8LYzCvzK0UJy00EveDJ7IFKe5ZuVdDvUCA805dNwxVFP6PXXjwGhDvrheMa8ZUAMgH8ve2q+Ye9OoO+r79rmB34V3Ybhs65OLoQBbFGlfvipARR0lib5lHWwgSx5yjTRGTFhxoI1Z+72OeaUK7wFChYu2nW499JwfPdTo+YxLMvW20iOAhVatBkzbZuDJRsuPOx33GlX+QgSIkKMFDekSsf1A6FJy3bXSmRddwlsd+3E1vWYSE0LirfpUPt02cJNfgwFyE7m4RLM/W6vSzjDY87DfNVPji6dLJuJF2/35lbuz//ls3BfynVt+gas8g+aTlyAABRQRxEFc+p33XRi7LaFHtITek6v6C2l7Cq7iRPJfvIUHCf4SmIwTOD0oeeu48BAL7mIp/A4x+/Tf+qMYQRDGMQADuIAmSDj5Go+5NH2Bw/gHtyBl6hLfariSub//FhTlPDZc3/oSN+DAtyLBbk88PAitpQp7dOgdxKXwCdja/IYRTGT+/+XznKXb0JfgO+v8ngp1853HdY5hjjfUI+y/UrTjTWw6ijtm9cy2lhz8EVXbHw4KB9VGf0WHrUUxn/izcZNNBSyPAkymTY5s5o0dPqKbQmvcIIwlDaZEbl02FSFqkvlXRz46pWObdxEu+J8mMbT+rAoluo4zX/aXcEhn21uqbumDJ0PTPHgQXfl5I0uK5uqjv9s3ti9nvw/cmmTPbaBRd2bjzxrcupz6QDosqEuGXxAQ6I/nhVp/8qzam1/7qxNPutoGkThnv62V4495/ugqjrB/7u9q4s/DoZ1ksoWMlQwlUIx2EheW6ddpWSEd1MM4JTh/uSfzg/r3TefxWPnzM4SGZmEDzuFRQ0rav8R7fNhoM4K/30zZiTsvwTWNi9/dv8MoU2t4upsfezKRccCRT/3S1pxaSPfrGkhBARICknx6eEE5n4hoz8/oelw7J7LqNxzvDz7RyCvzE5JwY2SkmOwDHV01HMmjvMPMx3d64tbpvTPCy1xBhM8Pi+f+zOTp5JJY+TOmHlENMsIxzNn1MPnczqB+9/L/5xFFjy9ILOn57PNOHw9+25r8n2E3O9xR/CwLELjB/Ux+L9e3Ov8dbRYkefpy4R4GQ6cVQe3/C046M1WT3okYeJxBv7fTs5DuVSm8Y/SR7N+1MJHIU7sX7V+DB8/53NB8K20A40gGHW034dS2v0+uD+541+NWMqy8f5QUlg4Oi5JDmNHWU5NQopmyTiTHAZEEpvQ2XO7apR2cflhIGxb1ecZ4waZVDC0UIJJNGFn5YKcIZhATgFp/Aa3s9FlgKUoVbqK24b1oTcsqu06I1jsoJyJJHH4hcNk3W88530OhHvBDFPS+eAPJArSZhKxUs9HCgcgflczJ+yteVMaHI/GfVT5g8qgFMZ4Dt0umjQ5xRwaj1hyhjPTh5R7tvd3ZyN9Mm8iSYd+PozYJ3QrmcrnpT5hvIdcq5nyhqXzenCfp36n3SCZ8xUiUlErg8ZicqIYSZw0AAG0OGeiwsxoSrwgVl3ZwxJATEGyenGoXFkfXxgB03IebVjqsKmtTtLDjNqZyKAzAS/lGEjX4IAvZTVOpYyCY5j3kWV+5H6fiiZD/E0Pe2UCIoPqscB0MPeUGsVqDWAm4MCpL1gyegBAnrrwp443gpiSRKDo3VKmMjPZb1xd3QYmxsffCB3O7rpNzOv2u6L9hqV9GFGSExAlmfakRrZL5bw1Q/MQXw5NVoNQGOPsNG4kg08fijMrYA8zGH4jqFhWlt/sculxHuUGdIZrpsaZPYRTQSrGeQOjrIrVrMDemmvv9+S6GXRUKeo70YundU2/Dd3qQj++jNuiKJuxgTlUoPmKoZuwYndrcRGbh4tOusHEtfR+1H74OYgbotZyAp+SC6n2omn9tR9thSPTdXqBPmJZOY3wYZiUzgMfCqaqaEOR9PYE3khL7YKr7DGuWXKFgvN+WsddnGzzwoB1mgeDfXe5TGHDwWSbrrBR5knY4A/CDzjGDqRbdUZY7d1Me+MZXtR8zVZ2UVVT8x5ATZIn07pW1SEHczqkzdsyDLiiA+iBJIKs5uQFnXXWwZoLrdMpug0WEPgm9vnVdLhe18IIxxGxwUVvdRELQWFC1hvMXRaiJe0DAFlxdrBtmxz6YRJ8385xl7XfdkWqY3a5JLdI3KSefGxAWdv9ao+J0XolZbLx1Rrxlfvul+8iaK5X1X0apVeeSa8UbjBqRlJwayv6ZFJybwDe3mEmgrk8xifXxGUtx6xz0Kft0ezsxSFppIIvxYqGqyYelfxhs68mD3ja8hpE6bZW3DQozgxTGZcf6SpjPjHjKLC8efyVt4zr4E+jZMFlTOiXPp753omLhCu07YId2ZscpbPlrdjmfVTczdjbKD13KRuQElvkBsJbSOZv/pcaXleHWVPezc+KqznVY1id1msOQh6r/RsKppuMHyiOOkdnlE7sBQJDGjrET6ChjqRA7ZTXYtS2+gYuhzdlK8NGo5fq19HOX9I1LCasQoDWr7/nzMXlhD+Sk4vtrTrdMYDIPjlMeQcaZla0f/JGtWoNsviKYBgFhS3dk419r7GR5vuKETEBCt1Z1qB+83TQleYNT541PsGTuwT9YfMAerntGbSbm+b85gc37/MWeW5wo/Z09aWBrS2fa3cOr+VQxLyASPQULwytjlnla9LZ3XWstRBu87aa7qTX7T0P6viXd2d8RXtKxK9Idel/vvJ5uQOC9NRgM4ubfpwPlcILiNOJENyzcdvYa+oN6ru48PEG8C5EevMCnbFS1SIUpp1Xm81XFeyD5GMdNvA2XYb9q7n8at9oNjZ+ybX17Kd14cCOpkn5avJhatWiderVfZV32GrjqTfo8uUrS76/mvMd7JPREj26QYtL/7pVd2Sz/NzpxYzphy8H3Dkt/eQu+UYJm63yVFTei3mb62yMhCAaEzLsrRAwtI/RoQxJcKiWey3bFDuYJJcb4d5OatrWTMs4ysFtA5z1mPw9XwyCIHcfg+cuSps7XsoDnJlomFkgd6SuYpuBDwYSK/1pG8HonXghxn7kZ914GPyto9FLSg5ScqiTolAy3A7/iD15DOvcfrttC+NTmbdhFFUhSYz7uGMg5a22QUKlBqiLcROGiT8yhOjve5ygLibA7sNeMhxyZYDwXpKI+KALXeQoUbSMEZVj0hePuhPI44RBFBPE+xT8EiIE3dCT2Hqk07OFGB6H/UMPEghwa3wYxzknLWpBGFxF/yBs4b+DyI7MaJGRLgrOdUdV0MQcuzVlhtuIKMxP8ogRxZ6JZmr04uDl5ZB7fk635QQJKSC30aA6LMhUZm4mv6h5x8btfPVQ9k9evY66zfSHL772dpu5Hm6ph7dEtxe9NZwf+hzIsfzl/dP6sH4fTPUdBA8dHG37/XqVmwQAAAA=) format("woff2");
     font-display: block;
   }
+  /* One block per palette, and light is the bare :root so the page is never
+     unpainted. The script above always stamps data-theme with a resolved
+     "light" or "dark" — following the OS is settled there rather than by a
+     prefers-color-scheme copy of the dark palette here. */
   :root {
     --bg: #faf9f6;
     --card: #ffffff;
@@ -37,24 +56,8 @@
     --thead: #857e75;
     --tip-bg: #2c2823;
     --tip-fg: #f5f1e9;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #171614;
-      --card: #1f1d1a;
-      --raise: #24211d;
-      --ink: #eae6df;
-      --muted: #9b948a;
-      --line: #34302a;
-      --line-soft: #282521;
-      --accent: #e08a72;
-      --accent-soft: #3a2822;
-      --glyph: #f3efe7;
-      --input-bg: #26231f;
-      --thead: #8d867c;
-      --tip-bg: #3a352e;
-      --tip-fg: #f2eee6;
-    }
+    --ok: #2f7d4f;
+    color-scheme: light;
   }
   :root[data-theme="dark"] {
     --bg: #171614;
@@ -71,22 +74,8 @@
     --thead: #8d867c;
     --tip-bg: #3a352e;
     --tip-fg: #f2eee6;
-  }
-  :root[data-theme="light"] {
-    --bg: #faf9f6;
-    --card: #ffffff;
-    --raise: #fbfaf7;
-    --ink: #211f1b;
-    --muted: #6e6862;
-    --line: #e5e1d8;
-    --line-soft: #efece5;
-    --accent: #a63a2b;
-    --accent-soft: #f3e4df;
-    --glyph: #16130f;
-    --input-bg: #ffffff;
-    --thead: #857e75;
-    --tip-bg: #2c2823;
-    --tip-fg: #f5f1e9;
+    --ok: #6cc48c;
+    color-scheme: dark;
   }
 
   * { box-sizing: border-box; }
@@ -108,8 +97,38 @@
     vertical-align: middle;
   }
 
-  header { margin-bottom: 26px; }
+  header { position: relative; margin-bottom: 26px; }
+  /* the control sits in the heading's own band, so the subtitle below it keeps
+     the full width and stays on one line */
+  .theme {
+    position: absolute;
+    top: 3px;
+    right: 0;
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+  }
+  .theme-opt {
+    font: inherit;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    background: none;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 9px;
+    cursor: pointer;
+  }
+  .theme-opt:hover { color: var(--ink); }
+  .theme-opt[aria-checked="true"] { color: var(--ink); background: var(--accent-soft); }
   header h1 {
+    /* clears the absolutely-positioned control above, which is ~162px wide */
+    padding-right: 176px;
     font-family: "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
     font-size: clamp(25px, 3.6vw, 34px);
     font-weight: 600;
@@ -720,7 +739,7 @@
   td.cp:hover .copy, td.cp:focus-within .copy { opacity: 1; pointer-events: auto; }
   td.cp .copy:hover { color: var(--accent); border-color: var(--accent); }
   td.cp:has(.copy:hover) .cv { color: var(--accent); }
-  td.cp .copy.done { color: #2f7d4f; border-color: #2f7d4f; opacity: 1; }
+  td.cp .copy.done { color: var(--ok); border-color: var(--ok); opacity: 1; }
 
   footer {
     margin-top: 42px;
@@ -779,6 +798,14 @@
 
 <div class="wrap">
   <header>
+    <div class="theme" role="radiogroup" aria-label="Color theme">
+      <button type="button" class="theme-opt" data-choice="auto" role="radio"
+              aria-checked="true">Auto</button>
+      <button type="button" class="theme-opt" data-choice="light" role="radio"
+              aria-checked="false" tabindex="-1">Light</button>
+      <button type="button" class="theme-opt" data-choice="dark" role="radio"
+              aria-checked="false" tabindex="-1">Dark</button>
+    </div>
     <h1>Sagittal Standard Notation Calculator</h1>
     <p class="sub">Enter a pitch as a ratio or as its prime exponents, choose the
       Pythagorean nominal to be your tonic, then choose your preferred Sagittal
@@ -2200,6 +2227,21 @@ if (typeof module !== "undefined") module.exports = SAG_PF;</script>
     }
   }
 
+  // Left/right arrows step through a group of buttons that share one roving
+  // focus — the notation tabs and the theme control are both this shape.
+  function arrowKeys(group, onAttr, pick) {
+    group.addEventListener("keydown", (e) => {
+      const step = e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0;
+      if (!step) return;
+      e.preventDefault();
+      const all = [...group.querySelectorAll("button")];
+      const next = all[(all.findIndex((b) => b.getAttribute(onAttr) === "true")
+        + step + all.length) % all.length];
+      pick(next);
+      next.focus();
+    });
+  }
+
   // ---------- tabs ----------
   // An inactive pane is display:none, and nothing inside one can be measured,
   // so every width the levels pane pins for itself is quietly skipped while it
@@ -2222,15 +2264,41 @@ if (typeof module !== "undefined") module.exports = SAG_PF;</script>
     }
   }
   for (const [tab] of TABS) $(tab).addEventListener("click", () => selectTab(tab));
-  document.querySelector(".tabs").addEventListener("keydown", (e) => {
-    const step = e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0;
-    if (!step) return;
-    e.preventDefault();
-    const at = TABS.findIndex(([tab]) => $(tab).getAttribute("aria-selected") === "true");
-    const [next] = TABS[(at + step + TABS.length) % TABS.length];
-    selectTab(next);
-    $(next).focus();
+  arrowKeys(document.querySelector(".tabs"), "aria-selected", (b) => selectTab(b.id));
+
+  // ---------- theme ----------
+  // The choice is what the user picked and is remembered; the palette on
+  // data-theme is what it resolves to now. They differ only under "auto".
+  const THEME_KEY = "sagittalCalculatorTheme";   // also read by the script in the head
+  const themeGroup = document.querySelector(".theme");
+  const themeOpts = [...themeGroup.querySelectorAll(".theme-opt")];
+  const prefersDark = matchMedia("(prefers-color-scheme: dark)");
+
+  function applyTheme(choice, remember) {
+    document.documentElement.dataset.themeChoice = choice;
+    document.documentElement.dataset.theme =
+      choice === "auto" ? (prefersDark.matches ? "dark" : "light") : choice;
+    for (const b of themeOpts) {
+      const on = b.dataset.choice === choice;
+      b.setAttribute("aria-checked", String(on));
+      b.tabIndex = on ? 0 : -1;
+    }
+    if (!remember) return;
+    try {
+      if (choice === "auto") localStorage.removeItem(THEME_KEY);
+      else localStorage.setItem(THEME_KEY, choice);
+    } catch (e) { /* no storage — the choice still holds for this visit */ }
+  }
+
+  for (const b of themeOpts) {
+    b.addEventListener("click", () => applyTheme(b.dataset.choice, true));
+  }
+  arrowKeys(themeGroup, "aria-checked", (b) => applyTheme(b.dataset.choice, true));
+  // only "auto" is listening; the other two ignore the OS by definition
+  prefersDark.addEventListener("change", () => {
+    applyTheme(document.documentElement.dataset.themeChoice, false);
   });
+  applyTheme(document.documentElement.dataset.themeChoice, false);
 
   // ---------- wiring ----------
   for (const p of P) expInputs[p].addEventListener("input", onVectorInput);

--- a/src/calculator/src/template.html
+++ b/src/calculator/src/template.html
@@ -9,12 +9,31 @@
   (https://scripts.sil.org/OFL). The subset uses the family name
   "SagittalGlyphs" per the OFL's Reserved Font Name rules.
 -->
+<script>
+// Settle the palette before the first paint, or the page flashes the other one.
+// data-theme carries the resolved palette the stylesheet keys on; the choice
+// behind it may be "auto", which tracks the OS for as long as it stays there.
+(() => {
+  "use strict";
+  const root = document.documentElement;
+  let stored = null;
+  try { stored = localStorage.getItem("sagittalCalculatorTheme"); } catch (e) { /* no storage */ }
+  const choice = stored === "light" || stored === "dark" ? stored : "auto";
+  root.dataset.themeChoice = choice;
+  root.dataset.theme = choice !== "auto" ? choice
+    : matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+})();
+</script>
 <style>
   @font-face {
     font-family: "SagittalGlyphs";
     src: url(data:font/woff2;base64,%%FONT_B64%%) format("woff2");
     font-display: block;
   }
+  /* One block per palette, and light is the bare :root so the page is never
+     unpainted. The script above always stamps data-theme with a resolved
+     "light" or "dark" — following the OS is settled there rather than by a
+     prefers-color-scheme copy of the dark palette here. */
   :root {
     --bg: #faf9f6;
     --card: #ffffff;
@@ -30,24 +49,8 @@
     --thead: #857e75;
     --tip-bg: #2c2823;
     --tip-fg: #f5f1e9;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #171614;
-      --card: #1f1d1a;
-      --raise: #24211d;
-      --ink: #eae6df;
-      --muted: #9b948a;
-      --line: #34302a;
-      --line-soft: #282521;
-      --accent: #e08a72;
-      --accent-soft: #3a2822;
-      --glyph: #f3efe7;
-      --input-bg: #26231f;
-      --thead: #8d867c;
-      --tip-bg: #3a352e;
-      --tip-fg: #f2eee6;
-    }
+    --ok: #2f7d4f;
+    color-scheme: light;
   }
   :root[data-theme="dark"] {
     --bg: #171614;
@@ -64,22 +67,8 @@
     --thead: #8d867c;
     --tip-bg: #3a352e;
     --tip-fg: #f2eee6;
-  }
-  :root[data-theme="light"] {
-    --bg: #faf9f6;
-    --card: #ffffff;
-    --raise: #fbfaf7;
-    --ink: #211f1b;
-    --muted: #6e6862;
-    --line: #e5e1d8;
-    --line-soft: #efece5;
-    --accent: #a63a2b;
-    --accent-soft: #f3e4df;
-    --glyph: #16130f;
-    --input-bg: #ffffff;
-    --thead: #857e75;
-    --tip-bg: #2c2823;
-    --tip-fg: #f5f1e9;
+    --ok: #6cc48c;
+    color-scheme: dark;
   }
 
   * { box-sizing: border-box; }
@@ -101,8 +90,38 @@
     vertical-align: middle;
   }
 
-  header { margin-bottom: 26px; }
+  header { position: relative; margin-bottom: 26px; }
+  /* the control sits in the heading's own band, so the subtitle below it keeps
+     the full width and stays on one line */
+  .theme {
+    position: absolute;
+    top: 3px;
+    right: 0;
+    display: inline-flex;
+    gap: 2px;
+    padding: 2px;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+  }
+  .theme-opt {
+    font: inherit;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    background: none;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 9px;
+    cursor: pointer;
+  }
+  .theme-opt:hover { color: var(--ink); }
+  .theme-opt[aria-checked="true"] { color: var(--ink); background: var(--accent-soft); }
   header h1 {
+    /* clears the absolutely-positioned control above, which is ~162px wide */
+    padding-right: 176px;
     font-family: "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
     font-size: clamp(25px, 3.6vw, 34px);
     font-weight: 600;
@@ -713,7 +732,7 @@
   td.cp:hover .copy, td.cp:focus-within .copy { opacity: 1; pointer-events: auto; }
   td.cp .copy:hover { color: var(--accent); border-color: var(--accent); }
   td.cp:has(.copy:hover) .cv { color: var(--accent); }
-  td.cp .copy.done { color: #2f7d4f; border-color: #2f7d4f; opacity: 1; }
+  td.cp .copy.done { color: var(--ok); border-color: var(--ok); opacity: 1; }
 
   footer {
     margin-top: 42px;
@@ -772,6 +791,14 @@
 
 <div class="wrap">
   <header>
+    <div class="theme" role="radiogroup" aria-label="Color theme">
+      <button type="button" class="theme-opt" data-choice="auto" role="radio"
+              aria-checked="true">Auto</button>
+      <button type="button" class="theme-opt" data-choice="light" role="radio"
+              aria-checked="false" tabindex="-1">Light</button>
+      <button type="button" class="theme-opt" data-choice="dark" role="radio"
+              aria-checked="false" tabindex="-1">Dark</button>
+    </div>
     <h1>Sagittal Standard Notation Calculator</h1>
     <p class="sub">Enter a pitch as a ratio or as its prime exponents, choose the
       Pythagorean nominal to be your tonic, then choose your preferred Sagittal
@@ -1878,6 +1905,21 @@
     }
   }
 
+  // Left/right arrows step through a group of buttons that share one roving
+  // focus — the notation tabs and the theme control are both this shape.
+  function arrowKeys(group, onAttr, pick) {
+    group.addEventListener("keydown", (e) => {
+      const step = e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0;
+      if (!step) return;
+      e.preventDefault();
+      const all = [...group.querySelectorAll("button")];
+      const next = all[(all.findIndex((b) => b.getAttribute(onAttr) === "true")
+        + step + all.length) % all.length];
+      pick(next);
+      next.focus();
+    });
+  }
+
   // ---------- tabs ----------
   // An inactive pane is display:none, and nothing inside one can be measured,
   // so every width the levels pane pins for itself is quietly skipped while it
@@ -1900,15 +1942,41 @@
     }
   }
   for (const [tab] of TABS) $(tab).addEventListener("click", () => selectTab(tab));
-  document.querySelector(".tabs").addEventListener("keydown", (e) => {
-    const step = e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0;
-    if (!step) return;
-    e.preventDefault();
-    const at = TABS.findIndex(([tab]) => $(tab).getAttribute("aria-selected") === "true");
-    const [next] = TABS[(at + step + TABS.length) % TABS.length];
-    selectTab(next);
-    $(next).focus();
+  arrowKeys(document.querySelector(".tabs"), "aria-selected", (b) => selectTab(b.id));
+
+  // ---------- theme ----------
+  // The choice is what the user picked and is remembered; the palette on
+  // data-theme is what it resolves to now. They differ only under "auto".
+  const THEME_KEY = "sagittalCalculatorTheme";   // also read by the script in the head
+  const themeGroup = document.querySelector(".theme");
+  const themeOpts = [...themeGroup.querySelectorAll(".theme-opt")];
+  const prefersDark = matchMedia("(prefers-color-scheme: dark)");
+
+  function applyTheme(choice, remember) {
+    document.documentElement.dataset.themeChoice = choice;
+    document.documentElement.dataset.theme =
+      choice === "auto" ? (prefersDark.matches ? "dark" : "light") : choice;
+    for (const b of themeOpts) {
+      const on = b.dataset.choice === choice;
+      b.setAttribute("aria-checked", String(on));
+      b.tabIndex = on ? 0 : -1;
+    }
+    if (!remember) return;
+    try {
+      if (choice === "auto") localStorage.removeItem(THEME_KEY);
+      else localStorage.setItem(THEME_KEY, choice);
+    } catch (e) { /* no storage — the choice still holds for this visit */ }
+  }
+
+  for (const b of themeOpts) {
+    b.addEventListener("click", () => applyTheme(b.dataset.choice, true));
+  }
+  arrowKeys(themeGroup, "aria-checked", (b) => applyTheme(b.dataset.choice, true));
+  // only "auto" is listening; the other two ignore the OS by definition
+  prefersDark.addEventListener("change", () => {
+    applyTheme(document.documentElement.dataset.themeChoice, false);
   });
+  applyTheme(document.documentElement.dataset.themeChoice, false);
 
   // ---------- wiring ----------
   for (const p of P) expInputs[p].addEventListener("input", onVectorInput);

--- a/src/calculator/tools/build.py
+++ b/src/calculator/tools/build.py
@@ -13,13 +13,17 @@ body = body.replace("%%CORE_JS%%", CORE.read_text(encoding="utf-8").strip())
 body = body.replace("%%PRIME_FACTOR_JS%%", PRIME_FACTOR.read_text(encoding="utf-8").strip())
 
 DIST.mkdir(exist_ok=True)
-(DIST / "artifact.html").write_text(body, encoding="utf-8")
+(DIST / "artifact.html").write_text(body, encoding="utf-8", newline="\n")
 
+# index.html is committed and the gate diffs it, so it is written with the line
+# endings git stores; letting Windows translate them leaves the tree dirty after
+# every build for a page that has not changed.
 INDEX.write_text(
     '<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n'
     '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
     "</head>\n<body>\n" + body + "\n</body>\n</html>\n",
     encoding="utf-8",
+    newline="\n",
 )
 
 print(f"index.html {INDEX.stat().st_size // 1024} KB")

--- a/src/calculator/tools/interactionSpec.js
+++ b/src/calculator/tools/interactionSpec.js
@@ -645,6 +645,40 @@
   ok("recovering restores it", onScreen(pfCard));
   pfCard.querySelector("summary").click();
 
+  // ---------- theme ----------
+  ok("the header carries a theme control",
+    Boolean(document.querySelector("header .theme")));
+
+  const themeOpt = (c) => document.querySelector('.theme-opt[data-choice="' + c + '"]');
+  const pageBg = () => getComputedStyle(document.body).backgroundColor;
+  themeOpt("light").click();
+  const lightBg = pageBg();
+  themeOpt("dark").click();
+  ok("choosing Dark repaints the page dark", lum(pageBg()) < lum(lightBg),
+    lightBg + " -> " + pageBg());
+
+  const stored = () => {
+    try { return localStorage.getItem("sagittalCalculatorTheme"); }
+    catch (e) { return "unavailable"; }
+  };
+  ok("the choice is remembered for the next visit", stored() === "dark", stored());
+  ok("only the chosen option is marked",
+    [...document.querySelectorAll(".theme-opt")]
+      .filter((b) => b.getAttribute("aria-checked") === "true")
+      .map((b) => b.dataset.choice).join() === "dark",
+    [...document.querySelectorAll(".theme-opt")]
+      .map((b) => b.dataset.choice + ":" + b.getAttribute("aria-checked")).join(" "));
+  ok("only the chosen option is in the tab order",
+    themeOpt("dark").tabIndex === 0 && themeOpt("auto").tabIndex === -1
+    && themeOpt("light").tabIndex === -1);
+
+  themeOpt("auto").click();
+  ok("Auto takes the palette from the OS",
+    document.documentElement.dataset.theme
+      === (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"),
+    document.documentElement.dataset.theme);
+  ok("Auto is the absence of a choice, not a stored one", !stored(), stored());
+
   const div = document.createElement("div");
   div.id = "TESTOUT";
   div.textContent = out.join("\n");

--- a/src/calculator/tools/shot.py
+++ b/src/calculator/tools/shot.py
@@ -1,9 +1,11 @@
 """Screenshot the built page in a given state, for looking at it.
 
-    python tools/shot.py <name> "<js to run once fonts are ready>" [w] [h] [scale]
+    python tools/shot.py <name> "<js to run once fonts are ready>" [w] [h] [scale] [theme]
 
 Writes dist/<name>.png. The js runs after document.fonts.ready so the music
-font's metrics are already settled.
+font's metrics are already settled. theme is "auto", "light" (the default) or
+"dark", and is picked through the page's own control, so the control and the
+palette in the shot agree.
 """
 import os
 import subprocess
@@ -22,19 +24,22 @@ js = sys.argv[2] if len(sys.argv) > 2 else ""
 width = sys.argv[3] if len(sys.argv) > 3 else "1180"
 height = sys.argv[4] if len(sys.argv) > 4 else "1200"
 scale = sys.argv[5] if len(sys.argv) > 5 else "1"
+theme = sys.argv[6] if len(sys.argv) > 6 else "light"
 
 DIST.mkdir(exist_ok=True)
+js = "document.querySelector('.theme-opt[data-choice=\"" + theme + "\"]').click();" + js
 page = INDEX.read_text(encoding="utf-8").replace(
-    '<html lang="en">', '<html lang="en" data-theme="light">')
-if js:
-    page = page.replace(
-        "</body>", "<script>document.fonts.ready.then(() => {" + js + "});</script></body>")
+    "</body>", "<script>document.fonts.ready.then(() => {" + js + "});</script></body>")
 harness = DIST / f"{name}.html"
 harness.write_text(page, encoding="utf-8")
 
 out = DIST / f"{name}.png"
 subprocess.run(
+    # reduced motion, or a shot lands mid-transition: switching the theme
+    # repaints every button and input over 120ms, and the page in the picture
+    # is then halfway between the two palettes
     [BROWSERS[0], "--headless=new", "--disable-gpu", "--hide-scrollbars",
+     "--force-prefers-reduced-motion",
      f"--window-size={width},{height}", f"--force-device-scale-factor={scale}",
      "--virtual-time-budget=6000", f"--screenshot={out}", harness.as_uri()],
     capture_output=True, timeout=180)


### PR DESCRIPTION
Both palettes were already written into the stylesheet, but nothing ever chose
between them — the page followed `prefers-color-scheme` and that was that, so on
a dark desktop the calculator was dark with no way to say otherwise.

A three-way control in the heading now picks:

- **Auto** keeps following the OS, live, through a `matchMedia` listener.
- **Light** and **Dark** override it and are remembered in `localStorage`,
  wrapped in a `try` because a page opened from `file://` may have no storage.

A script in the head settles the palette before the first paint; leaving it to
the runtime at the foot of the body flashed the other one on every load.

Resolving "auto" there rather than in a media query is what lets each palette be
written once: there were four blocks — light, dark, and a second copy of each
behind `data-theme` — and there are now two. Light stays on the bare `:root` so
the page is never unpainted, and each root declares its `color-scheme`, which is
what native scrollbars and the diagram's range slider read.

Along the way:

- The arrow-key handling the notation tabs already had is shared with the new
  control, both being a row of buttons with one roving focus.
- The copied-cell tick was a hardcoded green dark enough to vanish against the
  dark card; it is now a variable with a value per palette.
- `tools/build.py` writes `index.html` with LF. On Windows `Path.write_text`
  translated to CRLF, so every local build left `git status` showing the page
  modified when nothing had changed.
- `tools/shot.py` picks its theme by clicking the control, and forces reduced
  motion — a shot taken during the 120ms palette transition caught the page
  halfway between the two.

Seven assertions cover the control in `tools/interactionSpec.js` (146 passing).
`coreSpec.mjs` and `primeFactorSpec.mjs` are green. `npm run test-full` does not
run on this machine — its Node 24 rejects a CommonJS named import from
`@sagittal/general` that Node 20 accepts, at helper-load time and before any
spec runs. The gate's Node 20 job is the check on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
