### PR TITLE
Check the TypeScript in the job named for it

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -16,6 +16,21 @@ jobs:
               with:
                   node-version: 20.x
             - run: npm i
+
+            # The two steps that read the TypeScript. Until they were added this
+            # job was named for a language it never checked: jasmine finds one
+            # spec in the whole repo and that spec asserts that true is truthy, so
+            # a type error or an unused import could land through a green gate.
+            - name: The types
+              run: npm run typecheck
+
+            # lint-check, not lint: the latter passes --fix and rewrites files,
+            # and a gate that edits the tree it is judging can never fail.
+            - name: The lint rules
+              run: npm run lint-check
+
+            # Kept for the specs to arrive into — jasmine errors on an empty spec
+            # tree, which is the whole reason the one trivial spec exists.
             - run: npm run test-full
 
     calculator:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,12 @@ import tseslint from "typescript-eslint"
 
 export default tseslint.config(
     {
-        ignores: ["**/*.js", "**/*.d.ts", "dist/*", "eslint.config.mjs"],
+        // Plain JavaScript is not linted here, whichever extension it wears. The
+        // typed rules below need every linted file to belong to a tsconfig, and
+        // the .mjs under src/calculator/tools belongs to none of them — it is
+        // node-run tooling, gated by the calculator job instead. eslint.config.mjs
+        // used to be named here alone; **/*.mjs is the rule it was one case of.
+        ignores: ["**/*.js", "**/*.mjs", "**/*.d.ts", "dist/*"],
     },
     eslint.configs.recommended,
     ...tseslint.configs.recommendedTypeChecked,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "test-full-names": "node -r ts-node/register/transpile-only node_modules/jasmine/bin/jasmine --full=true --names=true",
         "tmp": "node -r ts-node/register/transpile-only --max-old-space-size=131072 spec/helpers/shared/tmp/tmp.ts",
         "lint": "node --max-old-space-size=131072 ./node_modules/.bin/eslint . --fix",
+        "lint-check": "node --max-old-space-size=131072 ./node_modules/.bin/eslint .",
         "format": "prettier --write .",
         "typecheck": "node --max-old-space-size=131072 ./node_modules/.bin/tsc --noEmit",
         "check": "npm run typecheck && npm run lint && npm run format && npm run test-full"


### PR DESCRIPTION
The `typescript` gate ran `npm run test-full` and nothing else. Jasmine finds
exactly one spec in this repo and that spec asserts that true is truthy, so the
check reported green without ever reading a line of the source it is named for:
a type error, an unused import, or a violated typedef rule could land through it.

`typecheck` and `lint` already exist and are already bundled into `npm run check`
— CI just never ran either. It runs both now. Lint goes through a new
`lint-check` script rather than `lint`, because `lint` passes `--fix`, and a gate
that rewrites the tree it is judging cannot fail.

`test-full` stays. Jasmine errors on an empty spec tree, which is the only job
the trivial spec was ever doing, and it is where real specs will land.
